### PR TITLE
Refactor/use closures instead of delegates for viewmodel communications

### DIFF
--- a/ExampleMVVM/Application/AppDelegate.swift
+++ b/ExampleMVVM/Application/AppDelegate.swift
@@ -10,7 +10,7 @@ import UIKit
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-    let appDIContainer = AppDIContainer()
+    var appDIContainer: AppDIContainer? = AppDIContainer()
     var appFlowCoordinator: AppMainFlowCoordinator?
     var window: UIWindow?
     
@@ -23,9 +23,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         window?.rootViewController = navigationController
         appFlowCoordinator = AppMainFlowCoordinator(navigationController: navigationController,
-                                                    appDIContainer: appDIContainer)
+                                                    appDIContainer: appDIContainer!)
         appFlowCoordinator?.startMoviesSearchFlow()
         window?.makeKeyAndVisible()
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
+            // your code here
+            self.appDIContainer = nil
+            self.window?.rootViewController = nil
+        }
     
         return true
     }

--- a/ExampleMVVM/Application/AppDelegate.swift
+++ b/ExampleMVVM/Application/AppDelegate.swift
@@ -10,7 +10,7 @@ import UIKit
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-    var appDIContainer: AppDIContainer? = AppDIContainer()
+    let appDIContainer = AppDIContainer()
     var appFlowCoordinator: AppMainFlowCoordinator?
     var window: UIWindow?
     
@@ -23,15 +23,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         window?.rootViewController = navigationController
         appFlowCoordinator = AppMainFlowCoordinator(navigationController: navigationController,
-                                                    appDIContainer: appDIContainer!)
+                                                    appDIContainer: appDIContainer)
         appFlowCoordinator?.startMoviesSearchFlow()
         window?.makeKeyAndVisible()
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
-            // your code here
-            self.appDIContainer = nil
-            self.window?.rootViewController = nil
-        }
     
         return true
     }

--- a/ExampleMVVM/Application/DIContainer/MoviesSceneDIContainer.swift
+++ b/ExampleMVVM/Application/DIContainer/MoviesSceneDIContainer.swift
@@ -52,14 +52,14 @@ final class MoviesSceneDIContainer {
     }
     
     // MARK: - Movies List
-    func makeMoviesListViewController(actions: MoviesListViewModelActions) -> MoviesListViewController {
-        return MoviesListViewController.create(with: makeMoviesListViewModel(actions: actions),
+    func makeMoviesListViewController(closures: MoviesListViewModelClosures) -> MoviesListViewController {
+        return MoviesListViewController.create(with: makeMoviesListViewModel(closures: closures),
                                                posterImagesRepository: makePosterImagesRepository())
     }
     
-    func makeMoviesListViewModel(actions: MoviesListViewModelActions) -> MoviesListViewModel {
+    func makeMoviesListViewModel(closures: MoviesListViewModelClosures) -> MoviesListViewModel {
         return DefaultMoviesListViewModel(searchMoviesUseCase: makeSearchMoviesUseCase(),
-                                          actions: actions)
+                                          closures: closures)
     }
     
     // MARK: - Movie Details
@@ -73,24 +73,24 @@ final class MoviesSceneDIContainer {
     }
     
     // MARK: - Movies Queries Suggestions List
-    func makeMoviesQueriesSuggestionsListViewController(actions: MoviesQueryListViewModelActions) -> UIViewController {
+    func makeMoviesQueriesSuggestionsListViewController(closures: MoviesQueryListViewModelClosures) -> UIViewController {
         if #available(iOS 13.0, *) { // SwiftUI
-            let view = MoviesQueryListView(viewModelWrapper: makeMoviesQueryListViewModelWrapper(actions: actions))
+            let view = MoviesQueryListView(viewModelWrapper: makeMoviesQueryListViewModelWrapper(closures: closures))
             return UIHostingController(rootView: view)
         } else { // UIKit
-            return MoviesQueriesTableViewController.create(with: makeMoviesQueryListViewModel(actions: actions))
+            return MoviesQueriesTableViewController.create(with: makeMoviesQueryListViewModel(closures: closures))
         }
     }
     
-    func makeMoviesQueryListViewModel(actions: MoviesQueryListViewModelActions) -> MoviesQueryListViewModel {
+    func makeMoviesQueryListViewModel(closures: MoviesQueryListViewModelClosures) -> MoviesQueryListViewModel {
         return DefaultMoviesQueryListViewModel(numberOfQueriesToShow: 10,
                                                fetchRecentMovieQueriesUseCaseFactory: makeFetchRecentMovieQueriesUseCase,
-                                               actions: actions)
+                                               closures: closures)
     }
 
     @available(iOS 13.0, *)
-    func makeMoviesQueryListViewModelWrapper(actions: MoviesQueryListViewModelActions) -> MoviesQueryListViewModelWrapper {
-        return MoviesQueryListViewModelWrapper(viewModel: makeMoviesQueryListViewModel(actions: actions))
+    func makeMoviesQueryListViewModelWrapper(closures: MoviesQueryListViewModelClosures) -> MoviesQueryListViewModelWrapper {
+        return MoviesQueryListViewModelWrapper(viewModel: makeMoviesQueryListViewModel(closures: closures))
     }
 
     // MARK: - Flow Coordinators

--- a/ExampleMVVM/Application/DIContainer/MoviesSceneDIContainer.swift
+++ b/ExampleMVVM/Application/DIContainer/MoviesSceneDIContainer.swift
@@ -52,13 +52,14 @@ final class MoviesSceneDIContainer {
     }
     
     // MARK: - Movies List
-    func makeMoviesListViewController() -> MoviesListViewController {
-        return MoviesListViewController.create(with: makeMoviesListViewModel(),
+    func makeMoviesListViewController(actions: MoviesListViewModelActions) -> MoviesListViewController {
+        return MoviesListViewController.create(with: makeMoviesListViewModel(actions: actions),
                                                posterImagesRepository: makePosterImagesRepository())
     }
     
-    func makeMoviesListViewModel() -> MoviesListViewModel {
-        return DefaultMoviesListViewModel(searchMoviesUseCase: makeSearchMoviesUseCase())
+    func makeMoviesListViewModel(actions: MoviesListViewModelActions) -> MoviesListViewModel {
+        return DefaultMoviesListViewModel(searchMoviesUseCase: makeSearchMoviesUseCase(),
+                                          actions: actions)
     }
     
     // MARK: - Movie Details
@@ -72,24 +73,24 @@ final class MoviesSceneDIContainer {
     }
     
     // MARK: - Movies Queries Suggestions List
-    func makeMoviesQueriesSuggestionsListViewController(delegate: MoviesQueryListViewModelDelegate) -> UIViewController {
+    func makeMoviesQueriesSuggestionsListViewController(actions: MoviesQueryListViewModelActions) -> UIViewController {
         if #available(iOS 13.0, *) { // SwiftUI
-            let view = MoviesQueryListView(viewModelWrapper: makeMoviesQueryListViewModelWrapper(delegate: delegate))
+            let view = MoviesQueryListView(viewModelWrapper: makeMoviesQueryListViewModelWrapper(actions: actions))
             return UIHostingController(rootView: view)
         } else { // UIKit
-            return MoviesQueriesTableViewController.create(with: makeMoviesQueryListViewModel(delegate: delegate))
+            return MoviesQueriesTableViewController.create(with: makeMoviesQueryListViewModel(actions: actions))
         }
     }
     
-    func makeMoviesQueryListViewModel(delegate: MoviesQueryListViewModelDelegate) -> MoviesQueryListViewModel {
+    func makeMoviesQueryListViewModel(actions: MoviesQueryListViewModelActions) -> MoviesQueryListViewModel {
         return DefaultMoviesQueryListViewModel(numberOfQueriesToShow: 10,
                                                fetchRecentMovieQueriesUseCaseFactory: makeFetchRecentMovieQueriesUseCase,
-                                               delegate: delegate)
+                                               actions: actions)
     }
 
     @available(iOS 13.0, *)
-    func makeMoviesQueryListViewModelWrapper(delegate: MoviesQueryListViewModelDelegate) -> MoviesQueryListViewModelWrapper {
-        return MoviesQueryListViewModelWrapper(viewModel: makeMoviesQueryListViewModel(delegate: delegate))
+    func makeMoviesQueryListViewModelWrapper(actions: MoviesQueryListViewModelActions) -> MoviesQueryListViewModelWrapper {
+        return MoviesQueryListViewModelWrapper(viewModel: makeMoviesQueryListViewModel(actions: actions))
     }
 
     // MARK: - Flow Coordinators

--- a/ExampleMVVM/Presentation/MoviesScene/FlowCoordinator/MoviesSearchFlowCoordinator.swift
+++ b/ExampleMVVM/Presentation/MoviesScene/FlowCoordinator/MoviesSearchFlowCoordinator.swift
@@ -28,6 +28,7 @@ class MoviesSearchFlowCoordinator {
     }
     
     func start() {
+        // Note: here we keep strong reference with closures, this way this flow do not need to be strong referenced
         let actions = MoviesListViewModelActions(showMovieDetails: showMovieDetails,
                                                  showMovieQueriesSuggestions: showMovieQueriesSuggestions,
                                                  closeMovieQueriesSuggestions: closeMovieQueriesSuggestions)

--- a/ExampleMVVM/Presentation/MoviesScene/FlowCoordinator/MoviesSearchFlowCoordinator.swift
+++ b/ExampleMVVM/Presentation/MoviesScene/FlowCoordinator/MoviesSearchFlowCoordinator.swift
@@ -8,9 +8,9 @@
 import UIKit
 
 protocol MoviesSearchFlowCoordinatorDependencies  {
-    func makeMoviesListViewController(actions: MoviesListViewModelActions) -> MoviesListViewController
+    func makeMoviesListViewController(closures: MoviesListViewModelClosures) -> MoviesListViewController
     func makeMoviesDetailsViewController(movie: Movie) -> UIViewController
-    func makeMoviesQueriesSuggestionsListViewController(actions: MoviesQueryListViewModelActions) -> UIViewController
+    func makeMoviesQueriesSuggestionsListViewController(closures: MoviesQueryListViewModelClosures) -> UIViewController
 }
 
 class MoviesSearchFlowCoordinator {
@@ -29,10 +29,10 @@ class MoviesSearchFlowCoordinator {
     
     func start() {
         // Note: here we keep strong reference with closures, this way this flow do not need to be strong referenced
-        let actions = MoviesListViewModelActions(showMovieDetails: showMovieDetails,
-                                                 showMovieQueriesSuggestions: showMovieQueriesSuggestions,
-                                                 closeMovieQueriesSuggestions: closeMovieQueriesSuggestions)
-        let vc = dependencies.makeMoviesListViewController(actions: actions)
+        let closures = MoviesListViewModelClosures(showMovieDetails: showMovieDetails,
+                                                   showMovieQueriesSuggestions: showMovieQueriesSuggestions,
+                                                   closeMovieQueriesSuggestions: closeMovieQueriesSuggestions)
+        let vc = dependencies.makeMoviesListViewController(closures: closures)
 
         navigationController.pushViewController(vc, animated: false)
         moviesListViewController = vc
@@ -46,8 +46,8 @@ class MoviesSearchFlowCoordinator {
     private func showMovieQueriesSuggestions(selectMovieQuery: @escaping (MovieQuery) -> Void) {
         guard let moviesListViewController = moviesListViewController,
             let container = moviesListViewController.suggestionsListContainer else { return }
-        let actions = MoviesQueryListViewModelActions(selectMovieQuery: selectMovieQuery)
-        let vc = dependencies.makeMoviesQueriesSuggestionsListViewController(actions: actions)
+        let closures = MoviesQueryListViewModelClosures(selectMovieQuery: selectMovieQuery)
+        let vc = dependencies.makeMoviesQueriesSuggestionsListViewController(closures: closures)
         moviesListViewController.add(child: vc, container: container)
         vc.view.frame = moviesListViewController.view.bounds
         moviesQueriesSuggestionsView = vc

--- a/ExampleMVVM/Presentation/MoviesScene/MoviesList/View/MoviesListViewController.swift
+++ b/ExampleMVVM/Presentation/MoviesScene/MoviesList/View/MoviesListViewController.swift
@@ -16,7 +16,7 @@ final class MoviesListViewController: UIViewController, StoryboardInstantiable, 
     @IBOutlet private var loadingView: UIActivityIndicatorView!
     @IBOutlet private var emptyDataLabel: UILabel!
     
-    private(set) var viewModel: MoviesListViewModel!
+    private var viewModel: MoviesListViewModel!
     private var posterImagesRepository: PosterImagesRepository?
     
     private var moviesTableViewController: MoviesListTableViewController?

--- a/ExampleMVVM/Presentation/MoviesScene/MoviesList/ViewModel/MoviesListViewModel.swift
+++ b/ExampleMVVM/Presentation/MoviesScene/MoviesList/ViewModel/MoviesListViewModel.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct MoviesListViewModelActions {
     let showMovieDetails: (Movie) -> Void
-    let showMovieQueriesSuggestions: (@escaping (MovieQuery) -> Void) -> Void
+    let showMovieQueriesSuggestions: (@escaping (_ didSelect: MovieQuery) -> Void) -> Void
     let closeMovieQueriesSuggestions: () -> Void
 }
 
@@ -142,7 +142,9 @@ extension DefaultMoviesListViewModel {
     }
 
     func showQueriesSuggestions() {
-        actions?.showMovieQueriesSuggestions(update(movieQuery:))
+        actions?.showMovieQueriesSuggestions { [weak self] query in
+            self?.update(movieQuery: query)
+        }
     }
     
     func closeQueriesSuggestions() {

--- a/ExampleMVVM/Presentation/MoviesScene/MoviesList/ViewModel/MoviesListViewModel.swift
+++ b/ExampleMVVM/Presentation/MoviesScene/MoviesList/ViewModel/MoviesListViewModel.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct MoviesListViewModelActions {
+struct MoviesListViewModelClosures {
     let showMovieDetails: (Movie) -> Void
     let showMovieQueriesSuggestions: (@escaping (_ didSelect: MovieQuery) -> Void) -> Void
     let closeMovieQueriesSuggestions: () -> Void
@@ -58,7 +58,7 @@ final class DefaultMoviesListViewModel: MoviesListViewModel {
     }
     private var movies: [Movie] = []
     private var moviesLoadTask: Cancellable? { willSet { moviesLoadTask?.cancel() } }
-    private var actions: MoviesListViewModelActions?
+    private var closures: MoviesListViewModelClosures?
     
     // MARK: - OUTPUT
     let items: Observable<[MoviesListItemViewModel]> = Observable([])
@@ -73,9 +73,9 @@ final class DefaultMoviesListViewModel: MoviesListViewModel {
 
     @discardableResult
     init(searchMoviesUseCase: SearchMoviesUseCase,
-         actions: MoviesListViewModelActions? = nil) {
+         closures: MoviesListViewModelClosures? = nil) {
         self.searchMoviesUseCase = searchMoviesUseCase
-        self.actions = actions
+        self.closures = closures
     }
     
     private func appendPage(moviesPage: MoviesPage) {
@@ -142,16 +142,16 @@ extension DefaultMoviesListViewModel {
     }
 
     func showQueriesSuggestions() {
-        actions?.showMovieQueriesSuggestions { [weak self] query in
+        closures?.showMovieQueriesSuggestions { [weak self] query in
             self?.update(movieQuery: query)
         }
     }
     
     func closeQueriesSuggestions() {
-        actions?.closeMovieQueriesSuggestions()
+        closures?.closeMovieQueriesSuggestions()
     }
     
     func didSelect(at indexPath: IndexPath) {
-        actions?.showMovieDetails(movies[indexPath.row])
+        closures?.showMovieDetails(movies[indexPath.row])
     }
 }

--- a/ExampleMVVM/Presentation/MoviesScene/MoviesList/ViewModel/MoviesListViewModel.swift
+++ b/ExampleMVVM/Presentation/MoviesScene/MoviesList/ViewModel/MoviesListViewModel.swift
@@ -7,11 +7,10 @@
 
 import Foundation
 
-enum MoviesListViewModelRoute {
-    case initial
-    case showMovieDetails(movie: Movie)
-    case showMovieQueriesSuggestions(delegate: MoviesQueryListViewModelDelegate)
-    case closeMovieQueriesSuggestions
+struct MoviesListViewModelActions {
+    let showMovieDetails: (Movie) -> Void
+    let showMovieQueriesSuggestions: (@escaping (MovieQuery) -> Void) -> Void
+    let closeMovieQueriesSuggestions: () -> Void
 }
 
 enum MoviesListViewModelLoading {
@@ -31,7 +30,6 @@ protocol MoviesListViewModelInput {
 }
 
 protocol MoviesListViewModelOutput {
-    var route: Observable<MoviesListViewModelRoute> { get }
     var items: Observable<[MoviesListItemViewModel]> { get }
     var loadingType: Observable<MoviesListViewModelLoading> { get }
     var query: Observable<String> { get }
@@ -60,9 +58,9 @@ final class DefaultMoviesListViewModel: MoviesListViewModel {
     }
     private var movies: [Movie] = []
     private var moviesLoadTask: Cancellable? { willSet { moviesLoadTask?.cancel() } }
+    private var actions: MoviesListViewModelActions?
     
     // MARK: - OUTPUT
-    let route: Observable<MoviesListViewModelRoute> = Observable(.initial)
     let items: Observable<[MoviesListItemViewModel]> = Observable([])
     let loadingType: Observable<MoviesListViewModelLoading> = Observable(.none)
     let query: Observable<String> = Observable("")
@@ -74,8 +72,10 @@ final class DefaultMoviesListViewModel: MoviesListViewModel {
     let searchBarPlaceholder = NSLocalizedString("Search Movies", comment: "")
 
     @discardableResult
-    init(searchMoviesUseCase: SearchMoviesUseCase) {
+    init(searchMoviesUseCase: SearchMoviesUseCase,
+         actions: MoviesListViewModelActions? = nil) {
         self.searchMoviesUseCase = searchMoviesUseCase
+        self.actions = actions
     }
     
     private func appendPage(moviesPage: MoviesPage) {
@@ -142,21 +142,14 @@ extension DefaultMoviesListViewModel {
     }
 
     func showQueriesSuggestions() {
-        route.value = .showMovieQueriesSuggestions(delegate: self)
+        actions?.showMovieQueriesSuggestions(update(movieQuery:))
     }
     
     func closeQueriesSuggestions() {
-        route.value = .closeMovieQueriesSuggestions
+        actions?.closeMovieQueriesSuggestions()
     }
     
     func didSelect(at indexPath: IndexPath) {
-        route.value = .showMovieDetails(movie: movies[indexPath.row])
-    }
-}
-
-// MARK: - Delegate method from another model views
-extension DefaultMoviesListViewModel: MoviesQueryListViewModelDelegate {
-    func moviesQueriesListDidSelect(movieQuery: MovieQuery) {
-        update(movieQuery: movieQuery)
+        actions?.showMovieDetails(movies[indexPath.row])
     }
 }

--- a/ExampleMVVM/Presentation/MoviesScene/MoviesQueriesList/ViewModel/MoviesQueryListViewModel.swift
+++ b/ExampleMVVM/Presentation/MoviesScene/MoviesQueriesList/ViewModel/MoviesQueryListViewModel.swift
@@ -7,6 +7,10 @@
 
 import Foundation
 
+struct MoviesQueryListViewModelActions {
+    var selectMovieQuery: (MovieQuery) -> Void
+}
+
 protocol MoviesQueryListViewModelInput {
     func viewWillAppear()
     func didSelect(item: MoviesQueryListItemViewModel)
@@ -17,10 +21,6 @@ protocol MoviesQueryListViewModelOutput {
 }
 
 protocol MoviesQueryListViewModel: MoviesQueryListViewModelInput, MoviesQueryListViewModelOutput { }
-
-struct MoviesQueryListViewModelActions {
-    var selectMovieQuery: (MovieQuery) -> Void
-}
 
 typealias FetchRecentMovieQueriesUseCaseFactory = (
     FetchRecentMovieQueriesUseCase.RequestValue,

--- a/ExampleMVVM/Presentation/MoviesScene/MoviesQueriesList/ViewModel/MoviesQueryListViewModel.swift
+++ b/ExampleMVVM/Presentation/MoviesScene/MoviesQueriesList/ViewModel/MoviesQueryListViewModel.swift
@@ -18,9 +18,8 @@ protocol MoviesQueryListViewModelOutput {
 
 protocol MoviesQueryListViewModel: MoviesQueryListViewModelInput, MoviesQueryListViewModelOutput { }
 
-protocol MoviesQueryListViewModelDelegate: class {
-    
-    func moviesQueriesListDidSelect(movieQuery: MovieQuery)
+struct MoviesQueryListViewModelActions {
+    var selectMovieQuery: (MovieQuery) -> Void
 }
 
 typealias FetchRecentMovieQueriesUseCaseFactory = (
@@ -32,17 +31,17 @@ final class DefaultMoviesQueryListViewModel: MoviesQueryListViewModel {
 
     private let numberOfQueriesToShow: Int
     private let fetchRecentMovieQueriesUseCaseFactory: FetchRecentMovieQueriesUseCaseFactory
-    private weak var delegate: MoviesQueryListViewModelDelegate?
+    private var actions: MoviesQueryListViewModelActions?
     
     // MARK: - OUTPUT
     let items: Observable<[MoviesQueryListItemViewModel]> = Observable([])
     
     init(numberOfQueriesToShow: Int,
          fetchRecentMovieQueriesUseCaseFactory: @escaping FetchRecentMovieQueriesUseCaseFactory,
-         delegate: MoviesQueryListViewModelDelegate? = nil) {
+         actions: MoviesQueryListViewModelActions? = nil) {
         self.numberOfQueriesToShow = numberOfQueriesToShow
         self.fetchRecentMovieQueriesUseCaseFactory = fetchRecentMovieQueriesUseCaseFactory
-        self.delegate = delegate
+        self.actions = actions
     }
     
     private func updateMoviesQueries() {
@@ -68,6 +67,6 @@ extension DefaultMoviesQueryListViewModel {
     }
     
     func didSelect(item: MoviesQueryListItemViewModel) {
-        delegate?.moviesQueriesListDidSelect(movieQuery: MovieQuery(query: item.query))
+        actions?.selectMovieQuery(MovieQuery(query: item.query))
     }
 }

--- a/ExampleMVVM/Presentation/MoviesScene/MoviesQueriesList/ViewModel/MoviesQueryListViewModel.swift
+++ b/ExampleMVVM/Presentation/MoviesScene/MoviesQueriesList/ViewModel/MoviesQueryListViewModel.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct MoviesQueryListViewModelActions {
+struct MoviesQueryListViewModelClosures {
     var selectMovieQuery: (MovieQuery) -> Void
 }
 
@@ -31,17 +31,17 @@ final class DefaultMoviesQueryListViewModel: MoviesQueryListViewModel {
 
     private let numberOfQueriesToShow: Int
     private let fetchRecentMovieQueriesUseCaseFactory: FetchRecentMovieQueriesUseCaseFactory
-    private var actions: MoviesQueryListViewModelActions?
+    private var closures: MoviesQueryListViewModelClosures?
     
     // MARK: - OUTPUT
     let items: Observable<[MoviesQueryListItemViewModel]> = Observable([])
     
     init(numberOfQueriesToShow: Int,
          fetchRecentMovieQueriesUseCaseFactory: @escaping FetchRecentMovieQueriesUseCaseFactory,
-         actions: MoviesQueryListViewModelActions? = nil) {
+         closures: MoviesQueryListViewModelClosures? = nil) {
         self.numberOfQueriesToShow = numberOfQueriesToShow
         self.fetchRecentMovieQueriesUseCaseFactory = fetchRecentMovieQueriesUseCaseFactory
-        self.actions = actions
+        self.closures = closures
     }
     
     private func updateMoviesQueries() {
@@ -67,6 +67,6 @@ extension DefaultMoviesQueryListViewModel {
     }
     
     func didSelect(item: MoviesQueryListItemViewModel) {
-        actions?.selectMovieQuery(MovieQuery(query: item.query))
+        closures?.selectMovieQuery(MovieQuery(query: item.query))
     }
 }

--- a/ExampleMVVMTests/Presentation/MoviesScene/MoviesQueriesListViewModelTests.swift
+++ b/ExampleMVVMTests/Presentation/MoviesScene/MoviesQueriesListViewModelTests.swift
@@ -82,14 +82,14 @@ class MoviesQueriesListViewModelTests: XCTestCase {
         let selectedQueryItem = MovieQuery(query: "query1")
         var actionMovieQuery: MovieQuery?
         let expectation = self.expectation(description: "Delegate notified")
-        let actions = MoviesQueryListViewModelActions(selectMovieQuery: { movieQuery in
+        let closures = MoviesQueryListViewModelClosures(selectMovieQuery: { movieQuery in
             actionMovieQuery = movieQuery
             expectation.fulfill()
         })
         
         let viewModel = DefaultMoviesQueryListViewModel(numberOfQueriesToShow: 3,
                                                         fetchRecentMovieQueriesUseCaseFactory: makeFetchRecentMovieQueriesUseCase(FetchRecentMovieQueriesUseCaseMock()),
-                                                        actions: actions)
+                                                        closures: closures)
         
         // when
         viewModel.didSelect(item: MoviesQueryListItemViewModel(query: selectedQueryItem.query))

--- a/ExampleMVVMTests/Presentation/MoviesScene/MoviesQueriesListViewModelTests.swift
+++ b/ExampleMVVMTests/Presentation/MoviesScene/MoviesQueriesListViewModelTests.swift
@@ -5,6 +5,7 @@
 //  Created by Oleh Kudinov on 16.08.19.
 //
 
+@testable import ExampleMVVM
 import XCTest
 
 class MoviesQueriesListViewModelTests: XCTestCase {
@@ -18,15 +19,6 @@ class MoviesQueriesListViewModelTests: XCTestCase {
                         MovieQuery(query: "query3"),
                         MovieQuery(query: "query4"),
                         MovieQuery(query: "query5")]
-    
-    class MoviesQueryListViewModelDelegateMock: MoviesQueryListViewModelDelegate {
-        var expectation: XCTestExpectation?
-        var didNotifiedWithMovieQuery: MovieQuery?
-        func moviesQueriesListDidSelect(movieQuery: MovieQuery) {
-            didNotifiedWithMovieQuery = movieQuery
-            expectation?.fulfill()
-        }
-    }
 
     class FetchRecentMovieQueriesUseCaseMock: UseCase {
         var expectation: XCTestExpectation?
@@ -85,21 +77,25 @@ class MoviesQueriesListViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.items.value.isEmpty)
     }
     
-    func test_whenDidSelectQueryEventIsReceived_thenNotifyDelegate() {
+    func test_whenDidSelectQueryEventIsReceived_thenCallAction() {
         // given
         let selectedQueryItem = MovieQuery(query: "query1")
-        let delegate = MoviesQueryListViewModelDelegateMock()
-        delegate.expectation = self.expectation(description: "Delegate notified")
+        var actionMovieQuery: MovieQuery?
+        let expectation = self.expectation(description: "Delegate notified")
+        let actions = MoviesQueryListViewModelActions(selectMovieQuery: { movieQuery in
+            actionMovieQuery = movieQuery
+            expectation.fulfill()
+        })
         
         let viewModel = DefaultMoviesQueryListViewModel(numberOfQueriesToShow: 3,
                                                         fetchRecentMovieQueriesUseCaseFactory: makeFetchRecentMovieQueriesUseCase(FetchRecentMovieQueriesUseCaseMock()),
-                                                        delegate: delegate)
+                                                        actions: actions)
         
         // when
         viewModel.didSelect(item: MoviesQueryListItemViewModel(query: selectedQueryItem.query))
         
         // then
         waitForExpectations(timeout: 5, handler: nil)
-        XCTAssertEqual(delegate.didNotifiedWithMovieQuery, selectedQueryItem)
+        XCTAssertEqual(actionMovieQuery, selectedQueryItem)
     }
 }


### PR DESCRIPTION
Refactor delegate to closures. Now ViewModels are totally isolated. Movies List does not import anything from Queries Lists (before it used its delegate)