### PR TITLE
Refactor/ Let cowork maxStorageLimit with query duplication

### DIFF
--- a/ExampleMVVM/Data/PersistentStorages/MoviesQueriesStorage/CoreDataStorage/CoreDataMoviesQueriesStorage.swift
+++ b/ExampleMVVM/Data/PersistentStorages/MoviesQueriesStorage/CoreDataStorage/CoreDataMoviesQueriesStorage.swift
@@ -20,13 +20,13 @@ final class CoreDataMoviesQueriesStorage {
 
     // MARK: - Private
     private func cleanUpQueries(for query: MovieQuery, inContext context: NSManagedObjectContext) throws {
-
+        let duplicationCheck = false
         let request: NSFetchRequest = MovieQueryEntity.fetchRequest()
         request.sortDescriptors = [NSSortDescriptor(key: #keyPath(MovieQueryEntity.createdAt),
                                                     ascending: false)]
         let result = try context.fetch(request)
-        result.filter { $0.query == query.query }.forEach { context.delete($0) }
-        if result.count > maxStorageLimit - 1 {
+        result.filter { $0.query == query.query }.forEach { context.delete($0); !duplicationCheck }
+        if duplicationCheck && result.count > maxStorageLimit - 1 {
             Array(result[maxStorageLimit - 1..<result.count]).forEach { context.delete($0) }
         }
     }


### PR DESCRIPTION
When duplicated query exists, although query is deleted in context but result's count do not know this. So, if there were originally 10 existing queries, even though the new query is duplicated thing, the other one is deleted, and only 9 queries appear in the list.
For Solving this, I added duplicationCheck.

Thank you.