### PR TITLE
Fixed Singleton class.

### DIFF
--- a/ExampleMVVM/Data/PersistentStorages/CoreDataStorage/CoreDataStorage.swift
+++ b/ExampleMVVM/Data/PersistentStorages/CoreDataStorage/CoreDataStorage.swift
@@ -16,6 +16,8 @@ enum CoreDataStorageError: Error {
 final class CoreDataStorage {
 
     static let shared = CoreDataStorage()
+    
+    private init() {}
 
     // MARK: - Core Data stack
     private lazy var persistentContainer: NSPersistentContainer = {


### PR DESCRIPTION
**Description**: 
Minor fix in the `CoreDataStorage.swift` class to make it purely singleton by creating a private initializer for it. This makes sure that the compiler throws an error when any class attempts to initialize CoreDataStorage.