### PR TITLE
DefaultMoviesQueriesRepository remove DataTransferService Properties

### DIFF
--- a/ExampleMVVM/Application/DIContainer/MoviesSceneDIContainer.swift
+++ b/ExampleMVVM/Application/DIContainer/MoviesSceneDIContainer.swift
@@ -46,7 +46,6 @@ final class MoviesSceneDIContainer: MoviesSearchFlowCoordinatorDependencies {
     }
     func makeMoviesQueriesRepository() -> MoviesQueriesRepository {
         DefaultMoviesQueriesRepository(
-            dataTransferService: dependencies.apiDataTransferService,
             moviesQueriesPersistentStorage: moviesQueriesStorage
         )
     }

--- a/ExampleMVVM/Data/Repositories/DefaultMoviesQueriesRepository.swift
+++ b/ExampleMVVM/Data/Repositories/DefaultMoviesQueriesRepository.swift
@@ -2,14 +2,9 @@ import Foundation
 
 final class DefaultMoviesQueriesRepository {
     
-    private let dataTransferService: DataTransferService
     private var moviesQueriesPersistentStorage: MoviesQueriesStorage
     
-    init(
-        dataTransferService: DataTransferService,
-        moviesQueriesPersistentStorage: MoviesQueriesStorage
-    ) {
-        self.dataTransferService = dataTransferService
+    init(moviesQueriesPersistentStorage: MoviesQueriesStorage) {
         self.moviesQueriesPersistentStorage = moviesQueriesPersistentStorage
     }
 }


### PR DESCRIPTION
DefaultMoviesQueriesRepository not use DataTransferService. That attribute is deprecated, but if it exists, it might confuse others, so we've removed it.